### PR TITLE
Fix regex

### DIFF
--- a/lib/linter-lua.coffee
+++ b/lib/linter-lua.coffee
@@ -13,7 +13,7 @@ class LinterLua extends Linter
     '^.+?:.+?:' +
     '(?<line>\\d+):\\s+' +
     '(?<message>.+?' +
-    '(?:near (?<near>\'.+\')|$))'
+    '(?:near (?<near>.+)|$))'
 
   errorStream: 'stderr'
 


### PR DESCRIPTION
Fix for lua 5.2:
```
local MIN_SP = －5
```
stderr output: `test.lua:1: unexpected symbol near char(239)
